### PR TITLE
fix: make demo/table work well

### DIFF
--- a/demo/table/package.json
+++ b/demo/table/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "../node_modules/.bin/webpack-dev-server --hotOnly",
+    "dev": "webpack-dev-server --hotOnly",
     "build": "../node_modules/.bin/webpack"
   },
   "devDependencies": {

--- a/demo/table/webpack.config.js
+++ b/demo/table/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = [
             contentBase: './',
             hot: true,
             port:9000, 
-            host:'30.10.61.70'
         },
         resolve:{
             alias:{


### PR DESCRIPTION
1. Npm scripts will run commands  which in node_modules at root of project automatically.
2. Remove host field in webpack-dev-server options.